### PR TITLE
Improve `camelCase`

### DIFF
--- a/test/camelCase.spec.ts
+++ b/test/camelCase.spec.ts
@@ -21,23 +21,17 @@ describe('"camelCase"', () => {
     it('Should keep empty strings empty', () => {
       expect(camelCase('')).to.equal('');
     });
+
+    it('Should return empty string when null or undefined is passed', () => {
+      expect(camelCase()).to.equal('');
+      expect(camelCase(null)).to.equal('');
+    });
   });
 
   describe('with defined settings', () => {
-    it('Should return a function if no string was given', () => {
-      expect(typeof camelCase()).to.equal('function');
-    });
-
-    it('Should always turn inputs into strings', () => {
-      const caser = camelCase() as Function;
-      expect(caser(null)).to.equal('');
-      expect(caser('')).to.equal('');
-      expect(caser(undefined)).to.equal('');
-    });
-
     describe('{ "abbr" : false, "upper" : false, "numbers" : true } (default settings)', () => {
       it('Should use default settings when an empty settings object is given', () => {
-        const caser = camelCase() as Function;
+        const caser = camelCase({}) as Function;
         expect(caser('Convert PHRASE into Camel case')).to.equal('convertPhraseIntoCamelCase');
         expect(caser('ABBR phrase')).to.equal('abbrPhrase');
         expect(caser('HTMLElement')).to.equal('htmlElement');

--- a/ts/camelCase.ts
+++ b/ts/camelCase.ts
@@ -1,5 +1,4 @@
 import isObject from './isObject';
-import isString from './isString';
 import phrasify, { PhrasifySettings } from './phrasify';
 
 
@@ -68,12 +67,23 @@ export default function camelCase(input?: CamelCaseSettings): CamelCaseFunction;
  * camelCase('XML data input'); // -> XmlDataInput
  * ```
  *
+ * The Ruels of the camel casing can be changed by giving it an object
+ *
+ * ```ts
+ * const camelCaseKeepAbbr = camelCase({ abbr: true });
+ * camelCaseKeepAbbr('XML data input'); // -> XMLDataInput
+ * ```
+ *
  * @param input - The string to format
  * @return - The formatted string
  */
 export default function camelCase(input: string): string;
 
 export default function camelCase(input?: string | CamelCaseSettings): string | CamelCaseFunction {
-  const opts = isObject(input) ? Object.assign({}, defaultSettings, input) : defaultSettings;
-  return isString(input) ? caser(opts, input as string) : (str: string) => caser(opts, str);
+  if (!isObject(input)) {
+    return caser(defaultSettings, input as string || '');
+  }
+
+  const opts = Object.assign({}, defaultSettings, input);
+  return (str: string) => caser(opts, str);
 }


### PR DESCRIPTION
Giving no arguments (or null) now returns empty string. Seems more logical.